### PR TITLE
Fix frequency display showing 'Nullx Per Week'

### DIFF
--- a/web/src/components/habits/HabitCard.tsx
+++ b/web/src/components/habits/HabitCard.tsx
@@ -12,7 +12,7 @@ interface Completion {
 interface Habit {
   id: string;
   name: string;
-  frequency: { type: string; daysPerWeek?: number; specificDays?: string[] };
+  frequency: { type: string; daysOfWeek?: string[]; dueDays?: string[]; daysPerWeek?: number; specificDays?: string[] };
   completions: Completion[];
 }
 

--- a/web/src/components/habits/HabitList.tsx
+++ b/web/src/components/habits/HabitList.tsx
@@ -9,7 +9,7 @@ interface Completion {
 interface Habit {
   id: string;
   name: string;
-  frequency: { type: string; daysPerWeek?: number; specificDays?: string[] };
+  frequency: { type: string; daysOfWeek?: string[]; dueDays?: string[]; daysPerWeek?: number; specificDays?: string[] };
   completions: Completion[];
 }
 

--- a/web/src/pages/HabitDetailPage.tsx
+++ b/web/src/pages/HabitDetailPage.tsx
@@ -15,14 +15,20 @@ import { computeStreaks } from '../hooks/streakCalc';
 import { useAuth } from '../auth/useAuth';
 import styles from './HabitDetailPage.module.css';
 
-function formatFrequency(frequency: { type: string; daysPerWeek?: number; specificDays?: string[] }): string {
+function formatFrequency(frequency: { type: string; daysOfWeek?: string[]; daysPerWeek?: number; specificDays?: string[] }): string {
   switch (frequency.type) {
     case 'DAILY':
       return 'Daily';
     case 'WEEKLY':
-      return `${frequency.daysPerWeek}x per week`;
-    case 'CUSTOM':
-      return frequency.specificDays?.map(d => d.slice(0, 3)).join(', ') || 'Custom';
+    case 'CUSTOM': {
+      const days = frequency.daysOfWeek || frequency.specificDays;
+      if (days && days.length > 0) {
+        if (days.length === 7) return 'Every day';
+        return days.map(d => d.slice(0, 3)).join(', ');
+      }
+      if (frequency.daysPerWeek) return `${frequency.daysPerWeek}x per week`;
+      return 'Weekly';
+    }
     default:
       return frequency.type;
   }


### PR DESCRIPTION
## Summary

Fix habit detail page showing "Nullx Per Week" for WEEKLY habits using the new `daysOfWeek` model. The old `formatFrequency` was reading `daysPerWeek` which is null for new habits.

Now shows:
- DAILY: "Daily"
- WEEKLY with specific days: "mon, wed, fri"
- WEEKLY with all 7 days: "Every day"
- Legacy WEEKLY with daysPerWeek: "3x per week"

Also updated Frequency type interfaces in HabitCard and HabitList.

## Test plan
- [ ] New WEEKLY habit shows day names (e.g., "mon, wed, sat")
- [ ] DAILY habit shows "Daily"
- [ ] Legacy habits display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)