### PR TITLE
Add edit habit from streak detail view

### DIFF
--- a/web/src/pages/StreakDetailPage.module.css
+++ b/web/src/pages/StreakDetailPage.module.css
@@ -1,8 +1,15 @@
-.backBtn {
+.topBar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--space-4);
+}
+
+.backBtn,
+.editBtn {
   padding: var(--space-2);
   border-radius: var(--radius-lg);
   color: var(--color-on-surface-variant, var(--color-neutral-500));
-  margin-bottom: var(--space-4);
   min-width: 44px;
   min-height: 44px;
   display: flex;
@@ -10,7 +17,8 @@
   justify-content: center;
 }
 
-.backBtn:hover {
+.backBtn:hover,
+.editBtn:hover {
   background: var(--color-surface-container, #e8f0e9);
 }
 

--- a/web/src/pages/StreakDetailPage.tsx
+++ b/web/src/pages/StreakDetailPage.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useQuery, useMutation } from '@apollo/client';
 import { GET_HABIT } from '../graphql/queries';
@@ -7,6 +7,7 @@ import { useStreak } from '../hooks/useStreak';
 import { getLocalDate } from '../utils/date';
 import PageShell from '../components/layout/PageShell';
 import CompleteButton from '../components/habits/CompleteButton';
+import HabitForm from '../components/habits/HabitForm';
 import StreakChain from '../components/streaks/StreakChain';
 import MotivationalBanner from '../components/streaks/MotivationalBanner';
 import StreakInsights from '../components/streaks/StreakInsights';
@@ -15,6 +16,7 @@ import styles from './StreakDetailPage.module.css';
 export default function StreakDetailPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
+  const [showEdit, setShowEdit] = useState(false);
   const { data, loading, error } = useQuery(GET_HABIT, { variables: { id } });
 
   const habit = data?.habit;
@@ -42,9 +44,16 @@ export default function StreakDetailPage() {
 
   return (
     <PageShell title="Streak">
-      <button className={styles.backBtn} onClick={() => navigate(-1)}>
-        <span className="material-symbols-outlined">arrow_back</span>
-      </button>
+      <div className={styles.topBar}>
+        <button className={styles.backBtn} onClick={() => navigate(-1)}>
+          <span className="material-symbols-outlined">arrow_back</span>
+        </button>
+        {habit && (
+          <button className={styles.editBtn} onClick={() => setShowEdit(true)}>
+            <span className="material-symbols-outlined">edit</span>
+          </button>
+        )}
+      </div>
 
       {loading && <p className={styles.status}>Loading...</p>}
       {error && <p className={styles.status}>Failed to load habit.</p>}
@@ -92,6 +101,10 @@ export default function StreakDetailPage() {
 
           <StreakInsights completions={habit.completions} frequency={habit.frequency} />
         </>
+      )}
+
+      {showEdit && habit && (
+        <HabitForm habit={habit} onClose={() => setShowEdit(false)} />
       )}
     </PageShell>
   );


### PR DESCRIPTION
## Summary
- Adds pencil (edit) icon button in the streak detail page top bar
- Opens the existing HabitForm modal in edit mode with pre-filled values
- Supports updating name, frequency, reminders, and deleting the habit

Closes #51

## Test plan
- [ ] Navigate to a habit's streak detail view
- [ ] Tap the edit (pencil) icon in the top-right
- [ ] Verify form opens with current habit values pre-filled
- [ ] Edit name and save — verify it updates
- [ ] Change frequency and save — verify it updates
- [ ] Delete habit — verify redirect to dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)