### PR TITLE
Redesign Settings page (Phase E)

### DIFF
--- a/web/src/pages/SettingsPage.module.css
+++ b/web/src/pages/SettingsPage.module.css
@@ -1,113 +1,258 @@
-.title {
-  font-size: var(--font-size-2xl);
-  font-weight: var(--font-weight-bold);
-  margin-bottom: var(--space-6);
+.pageTitle {
+  font-size: var(--font-size-3xl);
+  font-weight: 800;
+  color: var(--color-on-surface, var(--color-neutral-900));
+  letter-spacing: -0.02em;
+  margin-bottom: var(--space-8);
 }
 
 .section {
-  margin-bottom: var(--space-6);
-  padding: var(--space-4);
-  background: var(--color-surface-container-lowest, #ffffff);
-  border-radius: var(--radius-card-sm);
-  box-shadow: var(--shadow-sm);
+  margin-bottom: var(--space-8);
 }
 
 .sectionTitle {
   font-weight: var(--font-weight-semibold);
-  color: var(--color-neutral-500);
+  color: var(--color-on-surface-variant, var(--color-neutral-500));
   text-transform: uppercase;
-  letter-spacing: 0.05em;
+  letter-spacing: 0.08em;
   font-size: var(--font-size-xs);
-  margin-bottom: var(--space-3);
+  margin-bottom: var(--space-4);
+  padding: 0 var(--space-1);
 }
 
-.info {
-  display: flex;
-  justify-content: space-between;
-  padding: var(--space-2) 0;
-}
-
-.info:last-child {
-}
-
-.label {
-  color: var(--color-neutral-500);
-}
-
-.themeSelector {
+/* Theme selector */
+.themeGrid {
   display: grid;
   grid-template-columns: repeat(3, 1fr);
-  gap: var(--space-1);
-  background: var(--color-neutral-100);
-  border-radius: var(--radius-md);
-  padding: var(--space-1);
+  gap: var(--space-2);
+  background: var(--color-surface-container, #e8f0e9);
+  border-radius: var(--radius-card-sm);
+  padding: var(--space-2);
 }
 
 .themeBtn {
-  padding: var(--space-2) var(--space-3);
+  padding: var(--space-3);
   border: none;
-  border-radius: var(--radius-sm);
+  border-radius: var(--radius-xl);
   background: none;
   font-size: var(--font-size-sm);
-  font-weight: var(--font-weight-medium);
-  color: var(--color-neutral-600);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-on-surface-variant, var(--color-neutral-500));
   cursor: pointer;
   transition: all var(--transition-fast);
 }
 
 .themeBtn:hover {
-  color: var(--color-neutral-800);
+  color: var(--color-on-surface, var(--color-neutral-900));
 }
 
 .themeBtnActive {
-  background: var(--color-surface);
-  color: var(--color-primary-600);
+  background: var(--color-surface-container-lowest, #ffffff);
+  color: var(--color-primary, var(--color-primary-600));
   box-shadow: var(--shadow-sm);
 }
 
-.adminBtn {
-  width: 100%;
-  padding: var(--space-3);
-  border: none;
-  border-radius: var(--radius-lg);
-  color: var(--color-primary-600);
-  font-weight: var(--font-weight-medium);
+/* Account info rows */
+.infoRow {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-4);
+  background: var(--color-surface-container-lowest, #ffffff);
+  border-radius: var(--radius-card-sm);
   margin-bottom: var(--space-3);
-  background: var(--color-surface-container, var(--color-neutral-200));
+}
+
+.infoIcon {
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius-xl);
+  background: var(--color-surface-container, #e8f0e9);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-on-surface-variant, var(--color-neutral-500));
+  flex-shrink: 0;
+}
+
+.infoIcon .material-symbols-outlined {
+  font-size: 20px;
+}
+
+.infoContent {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.infoLabel {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-on-surface-variant, var(--color-neutral-500));
+}
+
+.infoValue {
+  font-weight: var(--font-weight-medium);
+  color: var(--color-on-surface, var(--color-neutral-900));
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Integration rows */
+.integrationBtn {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-5);
+  background: var(--color-surface-container-lowest, #ffffff);
+  border-radius: var(--radius-card-sm);
+  margin-bottom: var(--space-3);
+  text-align: left;
+  transition: box-shadow var(--transition-fast);
+  border: none;
+}
+
+.integrationBtn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.integrationLeft {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+}
+
+.integrationIcon {
+  width: 40px;
+  height: 40px;
+  border-radius: var(--radius-full);
+  background: var(--color-surface-container-highest, #dde4dd);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-on-surface-variant, var(--color-neutral-500));
+  flex-shrink: 0;
+}
+
+.iconSecondary {
+  background: rgba(0, 88, 190, 0.1);
+  color: var(--color-secondary, #0058be);
+}
+
+.integrationIcon .material-symbols-outlined {
+  font-size: 20px;
+}
+
+.integrationName {
+  font-weight: var(--font-weight-bold);
+  color: var(--color-on-surface, var(--color-neutral-900));
+}
+
+.integrationDesc {
+  font-size: var(--font-size-xs);
+  color: var(--color-on-surface-variant, var(--color-neutral-500));
+  margin-top: 2px;
+}
+
+.comingSoon {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-bold);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--color-on-surface-variant, var(--color-neutral-500));
+  background: var(--color-surface-container, #e8f0e9);
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-full);
+}
+
+/* Version grid */
+.versionGrid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-3);
+}
+
+.versionItem {
+  padding: var(--space-4);
+  background: var(--color-surface-container-lowest, #ffffff);
+  border-radius: var(--radius-xl);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+}
+
+.versionLabel {
+  font-size: 10px;
+  font-weight: var(--font-weight-bold);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--color-on-surface-variant, var(--color-neutral-500));
+}
+
+.versionValue {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-on-surface, var(--color-neutral-900));
+  font-family: monospace;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Action buttons */
+.actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  margin-top: var(--space-8);
+}
+
+.actionBtn {
+  width: 100%;
+  padding: var(--space-4);
+  border: none;
+  border-radius: var(--radius-card-sm);
+  background: var(--color-surface-container-lowest, #ffffff);
+  color: var(--color-on-surface, var(--color-neutral-900));
+  font-weight: var(--font-weight-medium);
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
   transition: background var(--transition-fast);
 }
 
-.adminBtn:hover {
-  background: var(--color-surface-container-high, var(--color-neutral-300));
+.actionBtn:hover {
+  background: var(--color-surface-container, #e8f0e9);
 }
 
-.clearCacheBtn {
-  width: 100%;
-  padding: var(--space-3);
-  border: none;
-  border-radius: var(--radius-lg);
-  color: var(--color-neutral-600);
-  font-weight: var(--font-weight-medium);
-  margin-bottom: var(--space-3);
-  background: var(--color-surface-container, var(--color-neutral-200));
-  transition: background var(--transition-fast);
-}
-
-.clearCacheBtn:hover {
-  background: var(--color-surface-container-high, var(--color-neutral-300));
+.actionBtn .material-symbols-outlined {
+  font-size: 20px;
+  color: var(--color-on-surface-variant, var(--color-neutral-500));
 }
 
 .signOutBtn {
   width: 100%;
-  padding: var(--space-3);
+  padding: var(--space-4);
   border: none;
-  border-radius: var(--radius-lg);
+  border-radius: var(--radius-card-sm);
+  background: var(--color-error-light, var(--color-error-container));
   color: var(--color-error);
   font-weight: var(--font-weight-medium);
-  background: var(--color-error-light, var(--color-error-container));
-  transition: background var(--transition-fast);
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  transition: opacity var(--transition-fast);
 }
 
 .signOutBtn:hover {
-  background: var(--color-error-light);
+  opacity: 0.8;
+}
+
+.signOutBtn .material-symbols-outlined {
+  font-size: 20px;
 }

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -54,11 +54,12 @@ export default function SettingsPage() {
 
   return (
     <PageShell title="Settings">
-      <h1 className={styles.title}>Settings</h1>
+      <h1 className={styles.pageTitle}>Settings</h1>
 
-      <div className={styles.section}>
+      {/* Appearance */}
+      <section className={styles.section}>
         <h2 className={styles.sectionTitle}>Appearance</h2>
-        <div className={styles.themeSelector}>
+        <div className={styles.themeGrid}>
           {THEME_OPTIONS.map(opt => (
             <button
               key={opt.value}
@@ -70,59 +71,106 @@ export default function SettingsPage() {
             </button>
           ))}
         </div>
-      </div>
+      </section>
 
-      <div className={styles.section}>
+      {/* Account */}
+      <section className={styles.section}>
         <h2 className={styles.sectionTitle}>Account</h2>
-        <div className={styles.info}>
-          <span className={styles.label}>Email</span>
-          <span>{meData?.me?.email || auth.currentUser?.email || '—'}</span>
+        <div className={styles.infoRow}>
+          <div className={styles.infoIcon}>
+            <span className="material-symbols-outlined">mail</span>
+          </div>
+          <div className={styles.infoContent}>
+            <span className={styles.infoLabel}>Email</span>
+            <span className={styles.infoValue}>{meData?.me?.email || auth.currentUser?.email || '—'}</span>
+          </div>
         </div>
-        <div className={styles.info}>
-          <span className={styles.label}>Display Name</span>
-          <span>{meData?.me?.displayName || '—'}</span>
+        <div className={styles.infoRow}>
+          <div className={styles.infoIcon}>
+            <span className="material-symbols-outlined">person</span>
+          </div>
+          <div className={styles.infoContent}>
+            <span className={styles.infoLabel}>Display Name</span>
+            <span className={styles.infoValue}>{meData?.me?.displayName || '—'}</span>
+          </div>
         </div>
-      </div>
+      </section>
 
-      <div className={styles.section}>
+      {/* Integrations (placeholders) */}
+      <section className={styles.section}>
+        <h2 className={styles.sectionTitle}>Integrations</h2>
+        <button className={styles.integrationBtn} disabled>
+          <div className={styles.integrationLeft}>
+            <div className={`${styles.integrationIcon} ${styles.iconSecondary}`}>
+              <span className="material-symbols-outlined">sync</span>
+            </div>
+            <div>
+              <p className={styles.integrationName}>Sync with Calendar</p>
+              <p className={styles.integrationDesc}>Google, iCloud, or Outlook</p>
+            </div>
+          </div>
+          <span className={styles.comingSoon}>Soon</span>
+        </button>
+        <button className={styles.integrationBtn} disabled>
+          <div className={styles.integrationLeft}>
+            <div className={styles.integrationIcon}>
+              <span className="material-symbols-outlined">download</span>
+            </div>
+            <div>
+              <p className={styles.integrationName}>Export Data</p>
+              <p className={styles.integrationDesc}>Download your journey as CSV/JSON</p>
+            </div>
+          </div>
+          <span className={styles.comingSoon}>Soon</span>
+        </button>
+      </section>
+
+      {/* Version Info */}
+      <section className={styles.section}>
         <h2 className={styles.sectionTitle}>Version Info</h2>
-        <div className={styles.info}>
-          <span className={styles.label}>API Version</span>
-          <span>{versionData?.version?.commit || 'unknown'}</span>
+        <div className={styles.versionGrid}>
+          <div className={styles.versionItem}>
+            <span className={styles.versionLabel}>API</span>
+            <span className={styles.versionValue}>{versionData?.version?.commit?.slice(0, 7) || '—'}</span>
+          </div>
+          <div className={styles.versionItem}>
+            <span className={styles.versionLabel}>Web</span>
+            <span className={styles.versionValue}>{__APP_COMMIT__.slice(0, 7)}</span>
+          </div>
+          <div className={styles.versionItem}>
+            <span className={styles.versionLabel}>Branch</span>
+            <span className={styles.versionValue}>{__APP_BRANCH__}</span>
+          </div>
+          <div className={styles.versionItem}>
+            <span className={styles.versionLabel}>Deployed</span>
+            <span className={styles.versionValue}>{versionData?.version?.deployedAt?.split('T')[0] || '—'}</span>
+          </div>
         </div>
-        <div className={styles.info}>
-          <span className={styles.label}>API Deployed</span>
-          <span>{versionData?.version?.deployedAt || 'unknown'}</span>
-        </div>
-        <div className={styles.info}>
-          <span className={styles.label}>Web Version</span>
-          <span>{__APP_COMMIT__.slice(0, 7)}</span>
-        </div>
-        <div className={styles.info}>
-          <span className={styles.label}>Web Branch</span>
-          <span>{__APP_BRANCH__}</span>
-        </div>
+      </section>
+
+      {/* Actions */}
+      <div className={styles.actions}>
+        {isAdmin && (
+          <button className={styles.actionBtn} onClick={() => navigate('/admin')}>
+            <span className="material-symbols-outlined">admin_panel_settings</span>
+            Manage Access
+          </button>
+        )}
+        {isAdmin && (
+          <button className={styles.actionBtn} onClick={handleCopyToken}>
+            <span className="material-symbols-outlined">key</span>
+            {tokenCopied ? 'Token Copied!' : 'Copy Auth Token'}
+          </button>
+        )}
+        <button className={styles.actionBtn} onClick={handleClearCache}>
+          <span className="material-symbols-outlined">cached</span>
+          Clear Cache & Reload
+        </button>
+        <button className={styles.signOutBtn} onClick={handleSignOut}>
+          <span className="material-symbols-outlined">logout</span>
+          Sign Out
+        </button>
       </div>
-
-      {isAdmin && (
-        <button className={styles.adminBtn} onClick={() => navigate('/admin')}>
-          Manage Access
-        </button>
-      )}
-
-      {isAdmin && (
-        <button className={styles.clearCacheBtn} onClick={handleCopyToken}>
-          {tokenCopied ? 'Token Copied!' : 'Copy Auth Token'}
-        </button>
-      )}
-
-      <button className={styles.clearCacheBtn} onClick={handleClearCache}>
-        Clear Cache & Reload
-      </button>
-
-      <button className={styles.signOutBtn} onClick={handleSignOut}>
-        Sign Out
-      </button>
     </PageShell>
   );
 }


### PR DESCRIPTION
## Summary
- Editorial layout with large title and section headers
- Card-based account info rows with Material Symbols icons
- Theme selector with larger touch targets and rounded cards
- Integration placeholders (Calendar Sync, Export Data) with "Soon" badges
- 2x2 version grid with monospace values
- Icon-prefixed action buttons (Admin, Auth Token, Clear Cache)
- Sign Out in error-tinted card style

Final phase of the Kinetic Sanctuary redesign.

## Test plan
- [ ] Verify theme switching works for all 7 themes
- [ ] Verify account info displays correctly
- [ ] Verify version info shows API and Web commits
- [ ] Verify admin buttons show for admin users
- [ ] Verify Sign Out works
- [ ] Verify Clear Cache & Reload works

🤖 Generated with [Claude Code](https://claude.com/claude-code)