### PR TITLE
Fix FAB overlapping last habit check-in button

### DIFF
--- a/web/src/components/habits/HabitList.module.css
+++ b/web/src/components/habits/HabitList.module.css
@@ -2,4 +2,5 @@
   display: flex;
   flex-direction: column;
   gap: var(--space-4);
+  padding-bottom: 80px;
 }


### PR DESCRIPTION
## Summary
Add 80px bottom padding to habit list so the last card's check-in button isn't blocked by the fixed FAB.

Closes #63

## Test plan
- [ ] With 5+ habits, verify the last habit's toggle is fully accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)