### PR TITLE
Fix input text invisible on dark/IDE themes

### DIFF
--- a/web/src/components/habits/HabitForm.module.css
+++ b/web/src/components/habits/HabitForm.module.css
@@ -47,6 +47,7 @@
   border-radius: var(--radius-lg);
   font-size: var(--font-size-base);
   background: var(--color-surface-highest);
+  color: var(--color-on-surface);
 }
 
 .input:focus {

--- a/web/src/pages/LoginPage.module.css
+++ b/web/src/pages/LoginPage.module.css
@@ -77,6 +77,7 @@
   border: none;
   border-radius: var(--radius-lg);
   background: var(--color-surface-highest);
+  color: var(--color-on-surface);
   transition: background var(--transition-fast);
 }
 

--- a/web/src/styles/global.css
+++ b/web/src/styles/global.css
@@ -51,6 +51,7 @@ button {
 
 input, select, textarea {
   font: inherit;
+  color: inherit;
 }
 
 h1, h2, h3, h4 {


### PR DESCRIPTION
## Summary
- Add `color: inherit` to global input/select/textarea reset
- Add explicit `color: var(--color-on-surface)` to HabitForm and LoginPage inputs
- Fixes black text on dark backgrounds in all themes

Closes #65

## Test plan
- [ ] Edit a habit in Dark, Dracula, Nord, Solarized, Monokai — text visible
- [ ] Login page inputs readable in all themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)