### PR TITLE
Restructure navigation for Habits/Tasks/Settings

### DIFF
--- a/web/public/sw-notifications.js
+++ b/web/public/sw-notifications.js
@@ -63,7 +63,7 @@ self.addEventListener('notificationclick', function (event) {
   event.notification.close();
 
   var habitId = event.notification.data && event.notification.data.habitId;
-  var url = habitId ? '/streaks/' + habitId : '/';
+  var url = habitId ? '/habits/streaks/' + habitId : '/habits';
 
   event.waitUntil(
     self.clients.matchAll({ type: 'window', includeUncontrolled: true }).then(function (clients) {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -15,6 +15,7 @@ const DashboardPage = lazy(() => import('./pages/DashboardPage'));
 const HistoryPage = lazy(() => import('./pages/HistoryPage'));
 const StreaksPage = lazy(() => import('./pages/StreaksPage'));
 const StreakDetailPage = lazy(() => import('./pages/StreakDetailPage'));
+const TasksPage = lazy(() => import('./pages/TasksPage'));
 const SettingsPage = lazy(() => import('./pages/SettingsPage'));
 const AdminPage = lazy(() => import('./pages/AdminPage'));
 
@@ -26,7 +27,7 @@ function ReminderScheduler() {
 function LoginRoute() {
   const { user, loading } = useAuth();
   if (loading) return null;
-  if (user) return <Navigate to="/" replace />;
+  if (user) return <Navigate to="/habits" replace />;
   return <LoginPage />;
 }
 
@@ -40,13 +41,26 @@ export default function App() {
             <Routes>
               <Route path="/login" element={<LoginRoute />} />
               <Route path="/restricted" element={<RestrictedPage />} />
-              <Route path="/" element={<AuthGuard><DashboardPage /></AuthGuard>} />
-              <Route path="/history" element={<AuthGuard><HistoryPage /></AuthGuard>} />
-              <Route path="/streaks" element={<AuthGuard><StreaksPage /></AuthGuard>} />
-              <Route path="/streaks/:id" element={<AuthGuard><StreakDetailPage /></AuthGuard>} />
+
+              {/* Habits */}
+              <Route path="/habits" element={<AuthGuard><DashboardPage /></AuthGuard>} />
+              <Route path="/habits/history" element={<AuthGuard><HistoryPage /></AuthGuard>} />
+              <Route path="/habits/streaks" element={<AuthGuard><StreaksPage /></AuthGuard>} />
+              <Route path="/habits/streaks/:id" element={<AuthGuard><StreakDetailPage /></AuthGuard>} />
+
+              {/* Tasks */}
+              <Route path="/tasks" element={<AuthGuard><TasksPage /></AuthGuard>} />
+
+              {/* Settings & Admin */}
               <Route path="/settings" element={<AuthGuard><SettingsPage /></AuthGuard>} />
               <Route path="/admin" element={<AdminGuard><AdminPage /></AdminGuard>} />
-              <Route path="*" element={<Navigate to="/" replace />} />
+
+              {/* Backward compat redirects */}
+              <Route path="/" element={<Navigate to="/habits" replace />} />
+              <Route path="/history" element={<Navigate to="/habits/history" replace />} />
+              <Route path="/streaks" element={<Navigate to="/habits/streaks" replace />} />
+              <Route path="/streaks/:id" element={<Navigate to="/habits/streaks/:id" replace />} />
+              <Route path="*" element={<Navigate to="/habits" replace />} />
             </Routes>
           </Suspense>
         </BrowserRouter>

--- a/web/src/components/habits/HabitCard.tsx
+++ b/web/src/components/habits/HabitCard.tsx
@@ -26,7 +26,7 @@ export default function HabitCard({ habit }: { habit: Habit }) {
   return (
     <div
       className={`${styles.card} ${isCompletedToday ? styles.completed : ''}`}
-      onClick={() => navigate(`/streaks/${habit.id}`)}
+      onClick={() => navigate(`/habits/streaks/${habit.id}`)}
     >
       <div className={styles.info}>
         <h3 className={`${styles.name} ${isCompletedToday ? styles.nameCompleted : ''}`}>

--- a/web/src/components/layout/BottomNav.tsx
+++ b/web/src/components/layout/BottomNav.tsx
@@ -1,29 +1,30 @@
-import { NavLink } from 'react-router-dom';
+import { NavLink, useLocation } from 'react-router-dom';
 import styles from './BottomNav.module.css';
 
 const tabs = [
-  { to: '/', icon: 'today', label: 'Today' },
-  { to: '/history', icon: 'history', label: 'History' },
-  { to: '/streaks', icon: 'local_fire_department', label: 'Streaks' },
-  { to: '/settings', icon: 'settings', label: 'Settings' },
+  { to: '/habits', icon: 'self_improvement', label: 'Habits', match: '/habits' },
+  { to: '/tasks', icon: 'task_alt', label: 'Tasks', match: '/tasks' },
+  { to: '/settings', icon: 'settings', label: 'Settings', match: '/settings' },
 ] as const;
 
 export default function BottomNav() {
+  const location = useLocation();
+
   return (
     <nav className={styles.nav}>
-      {tabs.map(({ to, icon, label }) => (
-        <NavLink
-          key={to}
-          to={to}
-          end={to === '/'}
-          className={({ isActive }) =>
-            `${styles.tab} ${isActive ? styles.active : ''}`
-          }
-        >
-          <span className={`material-symbols-outlined ${styles.icon}`}>{icon}</span>
-          <span className={styles.label}>{label}</span>
-        </NavLink>
-      ))}
+      {tabs.map(({ to, icon, label, match }) => {
+        const isActive = location.pathname === match || location.pathname.startsWith(match + '/');
+        return (
+          <NavLink
+            key={to}
+            to={to}
+            className={`${styles.tab} ${isActive ? styles.active : ''}`}
+          >
+            <span className={`material-symbols-outlined ${styles.icon}`}>{icon}</span>
+            <span className={styles.label}>{label}</span>
+          </NavLink>
+        );
+      })}
     </nav>
   );
 }

--- a/web/src/components/layout/HabitSubNav.module.css
+++ b/web/src/components/layout/HabitSubNav.module.css
@@ -1,0 +1,43 @@
+.bar {
+  display: flex;
+  justify-content: center;
+  gap: var(--space-1);
+  padding: var(--space-2) var(--space-4);
+  margin-bottom: var(--space-4);
+}
+
+.tab {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-full);
+  text-decoration: none;
+  color: var(--color-on-surface-muted);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  transition: all var(--transition-fast);
+  -webkit-tap-highlight-color: transparent;
+}
+
+.tab:hover {
+  text-decoration: none;
+}
+
+.icon {
+  font-size: 18px;
+}
+
+.label {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+}
+
+.active {
+  color: var(--color-accent-on);
+  background: linear-gradient(135deg, var(--color-accent), var(--color-accent-light));
+}
+
+.active .icon {
+  font-variation-settings: 'FILL' 1;
+}

--- a/web/src/components/layout/HabitSubNav.tsx
+++ b/web/src/components/layout/HabitSubNav.tsx
@@ -1,0 +1,28 @@
+import { NavLink } from 'react-router-dom';
+import styles from './HabitSubNav.module.css';
+
+const tabs = [
+  { to: '/habits', icon: 'today', label: 'Today' },
+  { to: '/habits/history', icon: 'history', label: 'History' },
+  { to: '/habits/streaks', icon: 'local_fire_department', label: 'Streaks' },
+] as const;
+
+export default function HabitSubNav() {
+  return (
+    <div className={styles.bar}>
+      {tabs.map(({ to, icon, label }) => (
+        <NavLink
+          key={to}
+          to={to}
+          end={to === '/habits'}
+          className={({ isActive }) =>
+            `${styles.tab} ${isActive ? styles.active : ''}`
+          }
+        >
+          <span className={`material-symbols-outlined ${styles.icon}`}>{icon}</span>
+          <span className={styles.label}>{label}</span>
+        </NavLink>
+      ))}
+    </div>
+  );
+}

--- a/web/src/components/layout/PageShell.tsx
+++ b/web/src/components/layout/PageShell.tsx
@@ -5,12 +5,14 @@ import styles from './PageShell.module.css';
 interface Props {
   title: string;
   children: ReactNode;
+  subNav?: ReactNode;
 }
 
-export default function PageShell({ children }: Props) {
+export default function PageShell({ children, subNav }: Props) {
   return (
     <div className={styles.shell}>
       <main className={styles.main}>
+        {subNav}
         {children}
       </main>
       <BottomNav />

--- a/web/src/pages/DashboardPage.tsx
+++ b/web/src/pages/DashboardPage.tsx
@@ -8,6 +8,7 @@ import HabitForm from '../components/habits/HabitForm';
 import ProgressRing from '../components/dashboard/ProgressRing';
 import StreakBanner from '../components/dashboard/StreakBanner';
 import PageShell from '../components/layout/PageShell';
+import HabitSubNav from '../components/layout/HabitSubNav';
 import EmptyState from '../components/common/EmptyState';
 import styles from './DashboardPage.module.css';
 
@@ -72,7 +73,7 @@ export default function DashboardPage() {
   const streakInfo = useBestStreak(habits);
 
   return (
-    <PageShell title="Today">
+    <PageShell title="Today" subNav={<HabitSubNav />}>
       <header className={styles.dateHeader}>
         <h1 className={styles.dateTitle}>{format(new Date(), 'MMM d, yyyy')}</h1>
       </header>

--- a/web/src/pages/HistoryPage.tsx
+++ b/web/src/pages/HistoryPage.tsx
@@ -4,6 +4,7 @@ import { format, subDays, subMonths, differenceInDays, parseISO } from 'date-fns
 import { GET_HABITS, GET_STATS } from '../graphql/queries';
 import { getLocalDate } from '../utils/date';
 import PageShell from '../components/layout/PageShell';
+import HabitSubNav from '../components/layout/HabitSubNav';
 import MomentumHeatmap from '../components/history/MomentumHeatmap';
 import StatCard from '../components/history/StatCard';
 import HabitBreakdownCard from '../components/history/HabitBreakdownCard';
@@ -63,7 +64,7 @@ export default function HistoryPage() {
   }, [stats]);
 
   return (
-    <PageShell title="History">
+    <PageShell title="History" subNav={<HabitSubNav />}>
       <div className={styles.headerSection}>
         <div>
           <span className={styles.eyebrow}>Performance</span>

--- a/web/src/pages/StreakDetailPage.tsx
+++ b/web/src/pages/StreakDetailPage.tsx
@@ -6,6 +6,7 @@ import { LOG_COMPLETION, UNDO_COMPLETION } from '../graphql/mutations';
 import { useStreak } from '../hooks/useStreak';
 import { getLocalDate } from '../utils/date';
 import PageShell from '../components/layout/PageShell';
+import HabitSubNav from '../components/layout/HabitSubNav';
 import CompleteButton from '../components/habits/CompleteButton';
 import HabitForm from '../components/habits/HabitForm';
 import StreakChain from '../components/streaks/StreakChain';
@@ -43,7 +44,7 @@ export default function StreakDetailPage() {
   };
 
   return (
-    <PageShell title="Streak">
+    <PageShell title="Streak" subNav={<HabitSubNav />}>
       <div className={styles.topBar}>
         <button className={styles.backBtn} onClick={() => navigate(-1)}>
           <span className="material-symbols-outlined">arrow_back</span>

--- a/web/src/pages/StreaksPage.tsx
+++ b/web/src/pages/StreaksPage.tsx
@@ -3,6 +3,7 @@ import { useQuery } from '@apollo/client';
 import { GET_HABITS } from '../graphql/queries';
 import { useStreak } from '../hooks/useStreak';
 import PageShell from '../components/layout/PageShell';
+import HabitSubNav from '../components/layout/HabitSubNav';
 import styles from './StreaksPage.module.css';
 
 interface Completion {
@@ -24,7 +25,7 @@ function HabitStreakRow({ habit }: { habit: Habit }) {
   const best = Math.max(streaks.longest, habit.longestStreak ?? 0);
 
   return (
-    <button className={styles.card} onClick={() => navigate(`/streaks/${habit.id}`)}>
+    <button className={styles.card} onClick={() => navigate(`/habits/streaks/${habit.id}`)}>
       <div className={styles.info}>
         <h3 className={styles.habitName}>{habit.name}</h3>
         {streaks.current > 0 && (
@@ -54,7 +55,7 @@ export default function StreaksPage() {
   const habits: Habit[] = data?.habits ?? [];
 
   return (
-    <PageShell title="Streaks">
+    <PageShell title="Streaks" subNav={<HabitSubNav />}>
       <div className={styles.headerSection}>
         <span className={styles.eyebrow}>Consistency</span>
         <h1 className={styles.pageTitle}>Streaks</h1>

--- a/web/src/pages/TasksPage.module.css
+++ b/web/src/pages/TasksPage.module.css
@@ -1,0 +1,25 @@
+.headerSection {
+  margin-bottom: var(--space-8);
+}
+
+.eyebrow {
+  font-size: 11px;
+  font-weight: var(--font-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: var(--color-on-surface-muted);
+}
+
+.pageTitle {
+  font-size: var(--font-size-3xl);
+  font-weight: 800;
+  color: var(--color-on-surface);
+  letter-spacing: -0.02em;
+  margin-top: var(--space-1);
+}
+
+.status {
+  color: var(--color-on-surface-muted);
+  text-align: center;
+  padding: var(--space-8);
+}

--- a/web/src/pages/TasksPage.tsx
+++ b/web/src/pages/TasksPage.tsx
@@ -1,0 +1,14 @@
+import PageShell from '../components/layout/PageShell';
+import styles from './TasksPage.module.css';
+
+export default function TasksPage() {
+  return (
+    <PageShell title="Tasks">
+      <div className={styles.headerSection}>
+        <span className={styles.eyebrow}>Productivity</span>
+        <h1 className={styles.pageTitle}>Tasks</h1>
+      </div>
+      <p className={styles.status}>Task views coming in Phase 3.</p>
+    </PageShell>
+  );
+}


### PR DESCRIPTION
## Summary
- Bottom nav: Habits / Tasks / Settings (3 top-level tabs)
- HabitSubNav: Today / History / Streaks (sub-tabs within Habits section)
- Routes: `/habits/*`, `/tasks/*`, `/settings`
- Backward compat redirects for old paths (`/`, `/history`, `/streaks`)
- Placeholder TasksPage for Phase 3
- All internal links updated to new paths

Phase 2 of 4 for Tasks & Lists feature.

## Test plan
- [ ] Bottom nav shows 3 tabs: Habits, Tasks, Settings
- [ ] Habits tab shows sub-nav with Today/History/Streaks
- [ ] Tapping between sub-tabs works
- [ ] Tasks tab shows placeholder page
- [ ] Settings tab works
- [ ] Clicking a habit card goes to /habits/streaks/:id
- [ ] Old URLs (/, /history, /streaks) redirect correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)