### PR TITLE
Phase 4: Sort controls and move tasks between lists

### DIFF
--- a/web/src/components/tasks/SortControl.module.css
+++ b/web/src/components/tasks/SortControl.module.css
@@ -1,0 +1,26 @@
+.control {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.icon {
+  font-size: 18px;
+  color: var(--color-on-surface-muted);
+}
+
+.select {
+  padding: var(--space-1) var(--space-2);
+  border: none;
+  border-radius: var(--radius-lg);
+  background: var(--color-surface);
+  color: var(--color-on-surface);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  cursor: pointer;
+}
+
+.select:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--color-focus-ring);
+}

--- a/web/src/components/tasks/SortControl.tsx
+++ b/web/src/components/tasks/SortControl.tsx
@@ -1,0 +1,40 @@
+import { useMutation } from '@apollo/client';
+import { UPDATE_TASK_LIST } from '../../graphql/mutations';
+import styles from './SortControl.module.css';
+
+const SORT_OPTIONS = [
+  { value: 'MANUAL', label: 'Manual' },
+  { value: 'DUE_DATE', label: 'Due Date' },
+  { value: 'PRIORITY', label: 'Priority' },
+  { value: 'CREATED_AT', label: 'Created' },
+] as const;
+
+interface Props {
+  listId: string;
+  current: string;
+}
+
+export default function SortControl({ listId, current }: Props) {
+  const [updateList] = useMutation(UPDATE_TASK_LIST, {
+    refetchQueries: ['GetTaskLists'],
+  });
+
+  const handleChange = (value: string) => {
+    updateList({ variables: { id: listId, sortPreference: value } });
+  };
+
+  return (
+    <div className={styles.control}>
+      <span className={`material-symbols-outlined ${styles.icon}`}>sort</span>
+      <select
+        className={styles.select}
+        value={current}
+        onChange={(e) => handleChange(e.target.value)}
+      >
+        {SORT_OPTIONS.map(opt => (
+          <option key={opt.value} value={opt.value}>{opt.label}</option>
+        ))}
+      </select>
+    </div>
+  );
+}

--- a/web/src/components/tasks/TaskForm.tsx
+++ b/web/src/components/tasks/TaskForm.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { useMutation } from '@apollo/client';
+import { useMutation, useQuery } from '@apollo/client';
 import { CREATE_TASK, UPDATE_TASK, DELETE_TASK } from '../../graphql/mutations';
+import { GET_TASK_LISTS } from '../../graphql/queries';
 import ConfirmDialog from '../common/ConfirmDialog';
 import styles from './TaskForm.module.css';
 
@@ -35,8 +36,12 @@ export default function TaskForm({ task, listId, parentId, onClose }: Props) {
   const [description, setDescription] = useState(task?.description ?? '');
   const [priority, setPriority] = useState(task?.priority ?? 'P4');
   const [dueDate, setDueDate] = useState(task?.dueDate ?? '');
+  const [selectedListId, setSelectedListId] = useState(task?.listId ?? listId ?? '');
   const [error, setError] = useState('');
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+  const { data: listsData } = useQuery(GET_TASK_LISTS);
+  const lists = listsData?.taskLists ?? [];
 
   const refetchQueries = ['GetTasks', 'GetTaskLists', 'GetTask'];
   const [createTask, { loading: creating }] = useMutation(CREATE_TASK, { refetchQueries });
@@ -58,11 +63,12 @@ export default function TaskForm({ task, listId, parentId, onClose }: Props) {
       dueDate: dueDate || null,
     };
 
+    if (selectedListId) input.listId = selectedListId;
+
     try {
       if (isEdit) {
         await updateTask({ variables: { id: task.id, input } });
       } else {
-        if (listId) input.listId = listId;
         if (parentId) input.parentId = parentId;
         await createTask({ variables: { input } });
       }
@@ -123,6 +129,21 @@ export default function TaskForm({ task, listId, parentId, onClose }: Props) {
               className={styles.input}
             />
           </label>
+
+          {lists.length > 0 && !parentId && (
+            <label className={styles.label}>
+              List
+              <select
+                value={selectedListId}
+                onChange={(e) => setSelectedListId(e.target.value)}
+                className={styles.input}
+              >
+                {lists.map((l: { id: string; name: string }) => (
+                  <option key={l.id} value={l.id}>{l.name}</option>
+                ))}
+              </select>
+            </label>
+          )}
 
           {error && <p className={styles.error}>{error}</p>}
 

--- a/web/src/pages/TasksPage.module.css
+++ b/web/src/pages/TasksPage.module.css
@@ -44,11 +44,19 @@
   }
 }
 
+.toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  margin-bottom: var(--space-4);
+}
+
 .addRow {
   display: flex;
   gap: var(--space-2);
   align-items: stretch;
-  margin-bottom: var(--space-4);
+  flex: 1;
 }
 
 .addRow > *:first-child {

--- a/web/src/pages/TasksPage.tsx
+++ b/web/src/pages/TasksPage.tsx
@@ -6,6 +6,7 @@ import ListSelector from '../components/tasks/ListSelector';
 import TaskCard from '../components/tasks/TaskCard';
 import TaskForm from '../components/tasks/TaskForm';
 import QuickAdd from '../components/tasks/QuickAdd';
+import SortControl from '../components/tasks/SortControl';
 import styles from './TasksPage.module.css';
 
 interface Task {
@@ -18,6 +19,7 @@ interface Task {
   dueDate?: string | null;
   completed: boolean;
   sortOrder: number;
+  createdAt?: string;
 }
 
 interface TaskNode extends Task {
@@ -46,6 +48,22 @@ function buildTree(tasks: Task[]): TaskNode[] {
     }));
   }
   return build(null);
+}
+
+function sortTasks(tasks: TaskNode[], pref: string): TaskNode[] {
+  const sorted = [...tasks];
+  switch (pref) {
+    case 'DUE_DATE':
+      return sorted.sort((a, b) => (a.dueDate ?? '9999') > (b.dueDate ?? '9999') ? 1 : -1);
+    case 'PRIORITY': {
+      const order: Record<string, number> = { P1: 1, P2: 2, P3: 3, P4: 4 };
+      return sorted.sort((a, b) => (order[a.priority] ?? 4) - (order[b.priority] ?? 4));
+    }
+    case 'CREATED_AT':
+      return sorted.sort((a, b) => (a.createdAt ?? '') > (b.createdAt ?? '') ? 1 : -1);
+    default: // MANUAL
+      return sorted.sort((a, b) => a.sortOrder - b.sortOrder);
+  }
 }
 
 function countSubtasks(allTasks: Task[], parentId: string): { total: number; completed: number } {
@@ -118,8 +136,11 @@ export default function TasksPage() {
   });
 
   const tasks: Task[] = tasksData?.tasks ?? [];
+  const activeList = lists.find(l => l.id === activeListId);
+  const sortPref = activeList?.sortPreference ?? 'MANUAL';
   const fullTree = useMemo(() => buildTree(tasks), [tasks]);
-  const tree = showCompleted ? fullTree : fullTree.filter(t => !t.completed);
+  const sortedTree = useMemo(() => sortTasks(fullTree, sortPref), [fullTree, sortPref]);
+  const tree = showCompleted ? sortedTree : sortedTree.filter(t => !t.completed);
   const completedCount = tasks.filter(t => t.completed && !t.parentId).length;
 
   return (
@@ -140,11 +161,14 @@ export default function TasksPage() {
         <div className={styles.content}>
           {activeListId && (
             <>
-              <div className={styles.addRow}>
-                <QuickAdd listId={activeListId} />
-                <button className={styles.fullFormBtn} onClick={() => setShowForm(true)} aria-label="New task with details">
-                  <span className="material-symbols-outlined">tune</span>
-                </button>
+              <div className={styles.toolbar}>
+                <div className={styles.addRow}>
+                  <QuickAdd listId={activeListId} />
+                  <button className={styles.fullFormBtn} onClick={() => setShowForm(true)} aria-label="New task with details">
+                    <span className="material-symbols-outlined">tune</span>
+                  </button>
+                </div>
+                <SortControl listId={activeListId} current={sortPref} />
               </div>
 
               {loading && <p className={styles.status}>Loading tasks...</p>}


### PR DESCRIPTION
## Summary
- **Sort control**: dropdown to sort by Manual, Due Date, Priority, or Created — saves preference per list
- **Move between lists**: TaskForm now includes a List picker when editing — change the list to move the task
- **Toolbar layout**: quick add + sort control on the same row

Final phase of Tasks & Lists feature.

## Test plan
- [x] Sort dropdown appears next to quick add
- [x] Changing sort reorders tasks immediately
- [x] Sort preference persists when navigating away and back
- [x] Edit a task → change List → save → task moves to new list
- [x] Creating via full form respects selected list

🤖 Generated with [Claude Code](https://claude.com/claude-code)